### PR TITLE
Fixed typo in content of Email APIs

### DIFF
--- a/content/en/email/java/simple-java-mail/index.md
+++ b/content/en/email/java/simple-java-mail/index.md
@@ -9,7 +9,7 @@ weight: 7
 
 ProductName: Simple Java Mail  
 Githublink: https://github.com/bbottema/simple-java-mail
-ListingPage_Short_Description: Open dource Java library supports creating email message with attachments or encrypt/decrypt messages, CLI support, S/MIME support and advanced batch processing.
+ListingPage_Short_Description: Open Source Java library supports creating email message with attachments or encrypt/decrypt messages, CLI support, S/MIME support and advanced batch processing.
 ListingPage_Product_Small_Image: listing-image.png 
 
 ---

--- a/content/en/email/net/mailkit/index.md
+++ b/content/en/email/net/mailkit/index.md
@@ -9,7 +9,7 @@ weight: 6
 
 ProductName: MailKit
 Githublink: https://github.com/jstedfast/MailKit
-ListingPage_Short_Description: Open dource C# .NET library for generating message with attachments or encrypt/decrypt messages with PGP/MIME and ARC signatures.
+ListingPage_Short_Description: Open Source C# .NET library for generating message with attachments or encrypt/decrypt messages with PGP/MIME and ARC signatures.
 ListingPage_Product_Small_Image: listing-image.png 
 
 ---


### PR DESCRIPTION
Typo in https://products.fileformat.com/email/java/ & https://products.fileformat.com/email/net/ for word "Open Source"